### PR TITLE
incompatibility between django 1.5 and simpleJson

### DIFF
--- a/account/forms.py
+++ b/account/forms.py
@@ -6,7 +6,7 @@
 """
 Core forms
 """
-import simplejson as json
+import json
 
 from django import forms
 from treeio.account.models import NotificationSetting, notification_types

--- a/core/administration/api/tests.py
+++ b/core/administration/api/tests.py
@@ -6,7 +6,7 @@
 """
 Core: test api
 """
-import simplejson as json
+import json
 from django.test import TestCase
 from django.test.client import Client
 from django.core.urlresolvers import reverse

--- a/core/dashboard/views.py
+++ b/core/dashboard/views.py
@@ -18,7 +18,7 @@ from treeio.core.dashboard.forms import WidgetForm
 from django.utils.translation import ugettext as _
 from treeio.core.conf import settings
 from jinja2 import Markup
-import simplejson as json
+import json
 import re
 import copy
 

--- a/core/decorators.py
+++ b/core/decorators.py
@@ -14,7 +14,7 @@ from django.utils.html import escape
 from jinja2.loaders import TemplateNotFound
 from treeio.core.models import Module
 from treeio.core.rss import verify_secret_key
-import simplejson as json
+import json
 import re
 
 def treeio_login_required(f):

--- a/core/management/commands/installdb.py
+++ b/core/management/commands/installdb.py
@@ -5,7 +5,7 @@
 
 from django.core.management.base import BaseCommand, CommandError
 from treeio.core.conf import settings
-import simplejson as json
+import json
 import subprocess
 from os import path
 import sys

--- a/core/middleware/chat.py
+++ b/core/middleware/chat.py
@@ -5,7 +5,7 @@
 
 # -*- coding:utf-8 -*-
 
-import simplejson as json
+import json
 from time import sleep
 from django.http import HttpResponse, HttpRequest
 from treeio.core.conf import settings

--- a/core/middleware/compress.py
+++ b/core/middleware/compress.py
@@ -11,7 +11,7 @@ from treeio.core.conf import settings
 
 def _minify_json(data):
     "Compress JSON"
-    import simplejson as json
+    import json
     return json.dumps(json.loads(data))
  
 class SpacelessMiddleware(object):

--- a/core/middleware/user.py
+++ b/core/middleware/user.py
@@ -21,7 +21,7 @@ from treeio.core.views import ajax_popup
 from treeio.core.conf import settings
 from django.db import models
 from django.core.cache import cache
-import simplejson as json
+import json
 import time
 
 

--- a/core/rendering.py
+++ b/core/rendering.py
@@ -13,7 +13,7 @@ from treeio.core.conf import settings
 from treeio.core.models import UpdateRecord
 from treeio.core.ajax.converter import preprocess_context as preprocess_context_ajax, convert_to_ajax
 import hashlib, random, os, codecs, re, subprocess
-import simplejson as json
+import json
 
 
 def _preprocess_context_html(context):

--- a/core/views.py
+++ b/core/views.py
@@ -28,7 +28,7 @@ from treeio.identities.models import ContactValue
 from jinja2 import Markup
 from os.path import join
 import re
-import simplejson as json
+import json
 import urllib2
 import random
 

--- a/documents/api/tests.py
+++ b/documents/api/tests.py
@@ -7,7 +7,7 @@
 Documents: test api
 """
 
-import simplejson as json
+import json
 from django.test import TestCase
 from django.test.client import Client
 from django.core.urlresolvers import reverse

--- a/events/api/tests.py
+++ b/events/api/tests.py
@@ -6,7 +6,7 @@
 """
 Events: test api
 """
-import simplejson as json
+import json
 from django.test import TestCase
 from django.test.client import Client
 from django.core.urlresolvers import reverse

--- a/finance/api/tests.py
+++ b/finance/api/tests.py
@@ -5,7 +5,7 @@
 
 #-*- coding: utf-8 -*-
 
-import simplejson as json
+import json
 from django.test import TestCase
 from django.test.client import Client
 from django.core.urlresolvers import reverse

--- a/identities/api/tests.py
+++ b/identities/api/tests.py
@@ -5,7 +5,7 @@
 
 #-*- coding: utf-8 -*-
 
-import simplejson as json
+import json
 from django.test import TestCase
 from treeio.identities.models import Contact, ContactType, ContactField
 from django.test.client import Client

--- a/infrastructure/api/tests.py
+++ b/infrastructure/api/tests.py
@@ -7,7 +7,7 @@
 Infrastructure: test api
 """
 
-import simplejson as json
+import json
 from django.test import TestCase
 from django.test.client import Client
 from django.core.urlresolvers import reverse

--- a/knowledge/api/tests.py
+++ b/knowledge/api/tests.py
@@ -6,7 +6,7 @@
 """
 Knowledge api: test suites
 """
-import simplejson as json
+import json
 from django.test import TestCase
 from django.test.client import Client
 from django.core.urlresolvers import reverse

--- a/messaging/api/tests.py
+++ b/messaging/api/tests.py
@@ -7,7 +7,7 @@
 Messaging: test api
 """
 
-import simplejson as json
+import json
 from django.test import TestCase
 from django.test.client import Client
 from django.core.urlresolvers import reverse

--- a/projects/api/tests.py
+++ b/projects/api/tests.py
@@ -7,7 +7,7 @@
 API Project Management: test suites
 """
 from time import sleep
-import simplejson as json
+import json
 from datetime import datetime
 from django.test import TestCase
 from django.test.client import Client

--- a/projects/views.py
+++ b/projects/views.py
@@ -21,7 +21,7 @@ from treeio.projects.forms import ProjectForm, MilestoneForm, TaskForm, FilterFo
                                     MassActionForm, TaskTimeSlotForm, TaskStatusForm, SettingsForm
 from django.utils.translation import ugettext as _
 from datetime import datetime
-import simplejson as json
+import json
 
 
 def _get_filter_query(args):

--- a/reports/templatetags/reports.py
+++ b/reports/templatetags/reports.py
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta
 import hashlib
 from treeio.reports.helpers import loads, aggregate_functions, number_field_regex
 from treeio.reports.views import _get_report_content
-import simplejson as json
+import json
 
 register = template.Library()
 

--- a/reports/views.py
+++ b/reports/views.py
@@ -22,7 +22,7 @@ from treeio.reports.models import Report, Field, Model, Chart
 from treeio.reports.helpers import dumps, loads, aggregate_functions, number_field_regex
 from itertools import groupby
 from datetime import datetime
-import simplejson as json
+import json
 import re
 
 def _get_default_context(request):

--- a/requirements.pip
+++ b/requirements.pip
@@ -15,7 +15,6 @@ django-simple-captcha
 unidecode
 django-websocket
 docutils
-simplejson
 sphinx
 johnny-cache
 django-pandora

--- a/sales/api/tests.py
+++ b/sales/api/tests.py
@@ -5,7 +5,7 @@
 
 #-*- codeing: utf-8 -*-
 
-import simplejson as json
+import json
 from django.test import TestCase
 from django.test.client import Client
 from django.core.urlresolvers import reverse

--- a/services/api/tests.py
+++ b/services/api/tests.py
@@ -6,7 +6,7 @@
 #-*- coding: utf-8 -*-
 
 import urllib
-import simplejson as json
+import json
 from django.test import TestCase
 from django.test.client import Client
 from django.core.urlresolvers import reverse


### PR DESCRIPTION
In all mi API call i have this error :

TypeError: **init**() got an unexpected keyword argument 'namedtuple_as_object'

this commit fix the problem :

https://github.com/derek-schaefer/django-json-field/issues/20
