### PR TITLE
Fixed #121.

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -511,6 +511,7 @@ def ajax_upload(request, object_id=None, record=None):
                 # is the "advanced" ajax upload
                 try:
                     filename = request.GET['qqfile']
+                    content_type = "application/octet-stream"
                 except KeyError:
                     return HttpResponseBadRequest("AJAX request not valid")
             # not an ajax upload, so it was the "basic" iframe version with
@@ -526,6 +527,7 @@ def ajax_upload(request, object_id=None, record=None):
                     # Thus, we can just grab the first (and only) value in the
                     # dict.
                     upload = request.FILES.values()[0]
+                    content_type = upload.content_type
                 else:
                     raise Http404("Bad Upload")
                 filename = upload.name
@@ -540,7 +542,7 @@ def ajax_upload(request, object_id=None, record=None):
             success = save_upload(upload, savefile, is_raw)
 
             attachment = Attachment(filename=filename,
-                                    mimetype=upload.content_type,
+                                    mimetype=content_type,
                                     uploaded_by=request.user.get_profile(),
                                     attached_file=filehash)
 

--- a/settings.py
+++ b/settings.py
@@ -59,8 +59,14 @@ OAUTH_DATA_STORE = 'treeio.core.api.auth.store.store'
 
 
 # Static files location for Tree.io
-STATIC_ROOT = path.join(PROJECT_ROOT, 'static')
-STATIC_URL = path.join(PROJECT_ROOT, 'static/')
+if not DEBUG:
+    STATIC_ROOT = path.join(PROJECT_ROOT, 'static')
+else:
+    STATICFILES_DIRS = (
+        path.join(PROJECT_ROOT, 'static'),
+    )
+    
+STATIC_URL = '/static/'
 STATIC_DOC_ROOT = path.join(PROJECT_ROOT, 'static')
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
@@ -568,3 +574,8 @@ MESSAGE_STORAGE = 'treeio.core.contrib.messages.storage.cache.CacheStorage'
 
 # Dajaxice settings
 DAJAXICE_MEDIA_PREFIX = "dajaxice"
+
+# Add django.contrib.staticfiles to make Dajaxice work if DEBUG = False.
+if not DEBUG:
+    INSTALLED_APPS += ('django.contrib.staticfiles',)
+    

--- a/urls.py
+++ b/urls.py
@@ -75,8 +75,6 @@ urlpatterns = patterns('',
 
     # Changed to backend (because it's backend!)
     (r'^backend/', include(admin.site.urls)),
-    (r'^static/(?P<path>.*)$', 'django.views.static.serve',
-     {'document_root': settings.STATIC_DOC_ROOT}),
 )
 
 

--- a/urls.py
+++ b/urls.py
@@ -82,4 +82,16 @@ if 'rosetta' in settings.INSTALLED_APPS:
     urlpatterns += patterns('',
                             url(r'^rosetta/', include('rosetta.urls')),
                             )
-urlpatterns += staticfiles_urlpatterns()
+                            
+if settings.DEBUG:
+    # Dajaxice depends on django.contrib.staticfiles to handle it.
+    # <STATIC_URL>/dajaxice.core.js is rendered by its DajaxiceFinder.
+    urlpatterns += staticfiles_urlpatterns()
+else:
+    # django.contrib.staticfiles won't work if DEBUG = False, we need to handle
+    # static files via django.views.static.serve.
+    urlpatterns +=   patterns('', 
+        (r'^static/(?P<path>.*)$', 'django.views.static.serve', {
+            'document_root': settings.STATIC_DOC_ROOT
+        }),
+    )


### PR DESCRIPTION
Fixed #121. If set DEBUG = False, you need to run python manage.py collectstatic first to generate Dajaxice's javascript files.
