### PR TITLE
Fixed #129. task assigned autocomplete ui bug.

### DIFF
--- a/static/patch.css
+++ b/static/patch.css
@@ -1,0 +1,4 @@
+/* https://github.com/treeio/treeio/issues/129 */
+.ui-autocomplete {
+  z-index: 99999;
+}

--- a/templates/html/base.html
+++ b/templates/html/base.html
@@ -61,6 +61,8 @@
     <script src="/static/js/jquery.dajax.core.js" type="text/javascript" charset="utf-8"></script>
     #} 
     {{ dajaxice_js_import() }}	
+    
+    <link rel="stylesheet" href="/static/patch.css" media="all" />
 </head>
 
 <body>


### PR DESCRIPTION
Append a patch.css to fix this.

I found there are many css files not included in treeio's source tree. There is only 26a.min.css but no source or instructions about how to build it. I guess the most important treeio3.css was built from static/styles/tree.less but I found that seems not synced (there is `.popup-block .ui-autocomplete` setting in it but not appeared in 26a.min.css). 

So I decided not to touch these files, just add a patch.css to fix this problem.