### PR TITLE
fix #144 - add explicity coffin version

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -2,7 +2,7 @@ Django==1.5.1
 Pygments==1.3.1
 south
 jinja2==2.5.2
-coffin
+coffin==0.4
 Pillow
 html5lib==0.90
 oauth2


### PR DESCRIPTION
If you make a fresh installation of coffin using the _requirements.py_ 
you wil got this error ...

```
File "/Volumes/p10G/oprj/treeio/../treeio/core/templatetags/modules.py", line 9, in <module>
    from coffin import template, shortcuts as coffinshortcuts
ImportError: cannot import name template
```

I just realized that coffin project has changed its API.
tree.io has to use the old version before 2.0 ... it means ==0.4
